### PR TITLE
Fixes #1: Arguments are not passed to the task script from the Enviro…

### DIFF
--- a/taskrunner
+++ b/taskrunner
@@ -38,4 +38,4 @@ taskrunner_run_task() {
 }
 task=$1
 [ ! "$task" ] && task="default"
-taskrunner_run_task $task "${@:3}"
+taskrunner_run_task $task "${*}"


### PR DESCRIPTION
Now all the arguments are passed from the environment and can be accessed starting from 2:

`arg1=${2}`

TODO: update the documentation.